### PR TITLE
Fix a regression where _duration_ wasn't used.

### DIFF
--- a/stickyfloat.js
+++ b/stickyfloat.js
@@ -128,7 +128,7 @@
                     if( duration < 5 || (settings.cssTransition && supportsTransitions) )
                         $obj[0].style.top = newpos + 'px';
                     else
-                        $obj.stop().delay(settings.delay).animate({ top: newpos }, 500, settings.easing );
+                        $obj.stop().delay(settings.delay).animate({ top: newpos }, duration, settings.easing );
                 }
             },
 


### PR DESCRIPTION
Introduced in 7df482d15b4b4dca22d702578502f880fd49263a.
