### PR TITLE
+ Add option `scrollWhenObjBiggerThanArea`

### DIFF
--- a/stickyfloat.js
+++ b/stickyfloat.js
@@ -20,6 +20,21 @@
  *
  **/
 
+(function(root, factory){
+
+  if (typeof define === 'function' && define.amd) {
+      // AMD. Register as an anonymous module.
+      define(['jquery'], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // Node/CommonJS
+    var jQuery = require('jquery');
+    module.exports = factory(jQuery);
+
+  }else{
+    // Browser globals
+    factory(root.jQuery);
+  }
+}(this, function(jQuery){
 (function($){
 	"use strict";
 
@@ -203,3 +218,4 @@
         });
     };
 })(jQuery);
+}));

--- a/stickyfloat.js
+++ b/stickyfloat.js
@@ -27,13 +27,14 @@
         doc = document,
         maxTopPos, minTopPos,
         defaults = {
-			scrollArea      : w,
-            duration        : 200,
-            lockBottom      : true,
-            delay           : 0,
-            easing          : 'linear',
-            stickToBottom   : false,
-            cssTransition   : false
+            scrollArea                  : w,
+            duration                    : 200,
+            lockBottom                  : true,
+            delay                       : 0,
+            easing                      : 'linear',
+            stickToBottom               : false,
+            cssTransition               : false,
+            scrollWhenObjBiggerThanArea : false
         },
         // detect CSS transitions support
         supportsTransitions = (function() {
@@ -120,7 +121,7 @@
 
                 // if window scrolled down more than startOffset OR obj position is greater than
                 // the top position possible (+ offsetY) AND window size must be bigger than Obj size
-                if( ((pastStartOffset || objFartherThanTopPos) && !objBiggerThanArea) || force ){
+                if( ((pastStartOffset || objFartherThanTopPos) && (settings.scrollWhenObjBiggerThanArea || !objBiggerThanArea)) || force ){
                     this.newpos = settings.stickToBottom ?
                                 areaScrollTop + areaHeight - this.stickyHeight - settings.startOffset - settings.offsetY :
                                 areaScrollTop - settings.startOffset + settings.offsetY;


### PR DESCRIPTION
when set to true, always scroll the element even when DOM object size is bigger than window

Addresses #21
# TODO
- [ ] Change to a better option name
- [ ] Update doc in comment
- [ ] Update doc in README 
